### PR TITLE
fix: vue version check

### DIFF
--- a/packages/core/src/declaration.ts
+++ b/packages/core/src/declaration.ts
@@ -112,7 +112,7 @@ export function getDeclaration(ctx: Context, filepath: string, originalImports?:
     directive: stringifyDeclarationImports({ ...originalImports?.directive, ...imports.directive }),
   }
 
-  const head = ctx.options.version === 2.7
+  const head = ctx.options.version >= 2.7
     ? `export {}
 
 declare module 'vue' {`


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing! We highly recommend reading [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer) first to get an idea of our current state, and we appreciate your understanding!
感谢你的贡献！我们非常推荐先阅读 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer) 以了解我们目前的状态，感谢你的理解！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

根据 Vue - Official 扩展文档 https://github.com/vuejs/language-tools/blob/70b5d862d0847d58dda9f2d78e30f9f75b11955d/extensions/vscode/README.md?plain=1#L91

Vue >= 2.7 时，应该使用如下类型声明：
```ts
declare module 'vue' {  // Vue >= 2.7
// declare module '@vue/runtime-dom' {  // Vue <= 2.6.14
  export interface GlobalComponents {
    RouterLink: typeof import('vue-router')['RouterLink']
    RouterView: typeof import('vue-router')['RouterView']
  }
}
```
当前 Vue 版本判断错误，导致在最新版本的 Vue - Official 扩展下 GlobalComponents 类型无法加载。

### Linked Issues 关联的 Issues

### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved compatibility for version checks by updating the comparison logic to support versions greater than or equal to 2.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->