### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 对于第三方组件([dcloudio/uni-ui](https://github.com/dcloudio/uni-ui)，[ano-ui](https://github.com/ano-ui/ano-ui)) 使用 `vite-plugin-uni-components` 会生成 `default` 属性，解决在 H5 端无法正确处理组件的问题。
 
 ```diff
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
 -   AButton: typeof import('ano-ui/components/AButton/AButton.vue')['AButton']
 +   AButton: typeof import('ano-ui/components/AButton/AButton.vue')['default']

--- a/playground/components.d.ts
+++ b/playground/components.d.ts
@@ -7,7 +7,7 @@ import '@vue/runtime-core'
 
 export {}
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     AButton: typeof import('ano-ui/components/AButton/AButton.vue')['default']
     Book: typeof import('./src/components/book/index.vue')['default']

--- a/test/__snapshots__/dts.test.ts.snap
+++ b/test/__snapshots__/dts.test.ts.snap
@@ -10,7 +10,7 @@ import '@vue/runtime-core'
 
 export {}
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
@@ -30,7 +30,7 @@ import '@vue/runtime-core'
 
 export {}
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     vLoading: typeof import('test/directive/Loading')['default']
   }
@@ -48,7 +48,7 @@ import '@vue/runtime-core'
 
 export {}
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
@@ -108,7 +108,7 @@ import '@vue/runtime-core'
 
 export {}
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
@@ -134,7 +134,7 @@ import '@vue/runtime-core'
 
 export {}
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -52,7 +52,7 @@ const _directive_loading = _resolveDirective("loading")`
     await writeFile(
       filepath,
       `
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     SomeComp: typeof import('test/component/SomeComp')['default']
     TestComp: typeof import('test/component/OldComp')['default']
@@ -132,7 +132,7 @@ import '@vue/runtime-core'
 
 export {}
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     ComponentA: typeof import('./src/components/ComponentA.vue')['default']
     ComponentB: typeof import('./src/components/ComponentB.vue')['default']
@@ -155,7 +155,7 @@ import '@vue/runtime-core'
 
 export {}
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     ComponentA: typeof import('./src/components/ComponentA.vue')['default']
     'IMdi:diceD12': typeof import('~icons/mdi/dice-d12')['default']
@@ -178,7 +178,7 @@ import '@vue/runtime-core'
 
 export {}
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     ComponentA: typeof import('./src/components/ComponentA.vue')['default']
     'IMdi:diceD12': typeof import('~icons/mdi/dice-d12')['default']


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing! We highly recommend reading [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer) first to get an idea of our current state, and we appreciate your understanding!
感谢你的贡献！我们非常推荐先阅读 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer) 以了解我们目前的状态，感谢你的理解！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

For a while, in the Vue ecosystem we've been augmenting `@vue/runtime-core` to add custom properties and more to `vue`. However, this inadvertently breaks the types for projects that augment `vue` - which is (now?) the officially recommended in the docs way to augment these interfaces (for example, [ComponentCustomProperties](https://vuejs.org/api/utility-types.html#componentcustomproperties), [GlobalComponents](https://vuejs.org/guide/extras/web-components.html#web-components-and-typescript) and [so on](https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties)).

This means _all_ libraries must update their code (or it will break the types of the libraries that augment `vue` instead).

[Here's an example](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgYygUwIYzQQTGOAXzgDMoIQ4ByANwFc0qAoJ5CAOwGd4N84BeFOiy58ACgSEAlCwD0suAAEYnALRoAHmDTIY6qOShwARhiOcAFhDoAbACYm0cGAE9tDjJ2owoDZmy54AH0MAC44djoQYzQjQV4wADoAkmAAc0S0mwhTGwAFcm1YYDRORNMoOQVlNU1tXX1DUggIOEtre0dnNzQPLyofP1YObjgg43DI6NiBOATkjlSMrJyMfMLYmBKykhaWOx0bMycQCDtbJ1o-RCY4OGB2bCgSDGQnAGEKSHY0R-e6bgUAoQIpbUo3O53XYQcKDNC3IhMQj7Q7HOCnc42S6KehoWS+R6gNCqNjoKgQ+6PWIvN5wT7gDi-GD-QEgYGg7YUu4VWG+eF3ZGEIA) of how the augmented types end up broken.

This PR is a small effort to ensure the ecosystem is consistent. For context, you can see that `vue-router` has [moved to do this](https://github.com/vuejs/router/pull/2295), as well as [Nuxt](https://github.com/nuxt/nuxt/pull/28542).

### Linked Issues 关联的 Issues

### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the import method for the `AButton` component to improve compatibility within the Vue.js environment.
	- Changed the module reference from `'@vue/runtime-core'` to `'vue'` across the codebase, enhancing module import management.

- **Bug Fixes**
	- Resolved potential issues with component rendering on the H5 platform.

- **Documentation**
	- Updated README.md to reflect changes in module declarations and component imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->